### PR TITLE
[Patch] Gem install command fixes (no-doc & no-ri)

### DIFF
--- a/lib/puppet/provider/rvm_gem/gem.rb
+++ b/lib/puppet/provider/rvm_gem/gem.rb
@@ -109,7 +109,7 @@ Puppet::Type.type(:rvm_gem).provide(:gem) do
         command << "--source" << "#{source}" << resource[:name]
       end
     else
-      command << "--no-rdoc" << "--no-ri" <<  resource[:name]
+      command << "-no-rdoc" << "-no-ri" <<  resource[:name]
     end
 
     # makefile opts,


### PR DESCRIPTION
Changes double hyphen on no-doc and no-ri to single hyphens as the double hyphens were breaking the installation of a gem.

Without this fix, the following error is reported by Puppet:

```
Error: Could not update: Execution of '/usr/local/rvm/bin/rvm ruby-2.3 do gem install -v 3.9.3 --no-rdoc --no-ri inspec' returned 1: ERROR:  While executing gem ... (OptionParser::InvalidOption)
    invalid option: --no-rdoc
Error: /Stage[main]/Rvm/Rvm_gem[inspec]/ensure: change from absent to 3.9.3 failed: Could not update: Execution of '/usr/local/rvm/bin/rvm ruby-2.3 do gem install -v 3.9.3 --no-rdoc --no-ri inspec' returned 1: ERROR:  While executing gem ... (OptionParser::InvalidOption)
    invalid option: --no-rdoc
Debug: Executing '/usr/local/rvm/bin/rvm ruby-2.3 do gem list --local ^capistrano$'
Debug: Executing '/usr/local/rvm/bin/rvm ruby-2.3 do gem install -v 2.14.1 --no-rdoc --no-ri capistrano'
Error: Could not update: Execution of '/usr/local/rvm/bin/rvm ruby-2.3 do gem install -v 2.14.1 --no-rdoc --no-ri capistrano' returned 1: ERROR:  While executing gem ... (OptionParser::InvalidOption)
    invalid option: --no-rdoc
Error: /Stage[main]/Rvm/Rvm_gem[capistrano]/ensure: change from absent to 2.14.1 failed: Could not update: Execution of '/usr/local/rvm/bin/rvm ruby-2.3 do gem install -v 2.14.1 --no-rdoc --no-ri capistrano' returned 1: ERROR:  While executing gem ... (OptionParser::InvalidOption)
    invalid option: --no-rdoc
Debug: Executing '/usr/local/rvm/bin/rvm ruby-2.3 do gem list --local ^nokogiri$'
Debug: Executing '/usr/local/rvm/bin/rvm ruby-2.3 do gem install -v 1.8.5 --no-rdoc --no-ri nokogiri'
Error: Could not update: Execution of '/usr/local/rvm/bin/rvm ruby-2.3 do gem install -v 1.8.5 --no-rdoc --no-ri nokogiri' returned 1: ERROR:  While executing gem ... (OptionParser::InvalidOption)
    invalid option: --no-rdoc
Error: /Stage[main]/Rvm/Rvm_gem[nokogiri]/ensure: change from absent to 1.8.5 failed: Could not update: Execution of '/usr/local/rvm/bin/rvm ruby-2.3 do gem install -v 1.8.5 --no-rdoc --no-ri nokogiri' returned 1: ERROR:  While executing gem ... (OptionParser::InvalidOption)
    invalid option: --no-rdoc
```

With the fix Puppet reports:

```
Notice: /Stage[main]/Rvm/Rvm_gem[inspec]/ensure: created
Notice: /Stage[main]/Rvm/Rvm_gem[capistrano]/ensure: created
Notice: /Stage[main]/Rvm/Rvm_gem[nokogiri]/ensure: created
```